### PR TITLE
Support FS25

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Adjustable Camera for Farming Simulator 22
+# Adjustable Camera for Farming Simulator 25
 
 This mod allows to move the position of the indoor camera.
 
@@ -6,7 +6,7 @@ Please configure your inputs as you wish as there are no defaults defined.
 
 [Download the latest release here](https://github.com/JanCraymer/FS22_AdjustableCamera/releases/latest)
 
-# Anpassbare Kamera für Landwirtschafts-Simulator 22
+# Anpassbare Kamera für Landwirtschafts-Simulator 25
 
 Dieser Mod ermöglicht es, die Innenansichtskameraposition anzupassen.
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ZIPFILE=FS22_AdjustableCamera.zip
+ZIPFILE=FS25_AdjustableCamera.zip
 if test -f "$ZIPFILE"; then
     echo "Deleting previous $ZIPFILE."
     rm $ZIPFILE

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
-<modDesc descVersion="75">
+<modDesc descVersion="92">
     <author>CptCray</author>
-    <version>1.0.1.0</version>
+    <version>2.0.0.0</version>
     <title>
         <en>Adjustable Camera</en>
         <de>Anpassbare Kamera</de>


### PR DESCRIPTION
Increase descVersion to support FS25.
I have been using it in FS25 for the past weeks without any errors and @VenoushCZ also mentioned it working for him in https://github.com/JanCraymer/FS22_AdjustableCamera/issues/7. It seems Giants did not change anything for the indoor camera, at least nothing that is relevant to AdjustableCamera.